### PR TITLE
Dma16

### DIFF
--- a/TMM-HM01B0/examples/hm01b0_testv3/hm01b0_testv3.ino
+++ b/TMM-HM01B0/examples/hm01b0_testv3/hm01b0_testv3.ino
@@ -83,7 +83,6 @@ ILI9341_t3n tft = ILI9341_t3n(TFT_CS, TFT_DC, TFT_RST);
 
 uint16_t FRAME_WIDTH, FRAME_HEIGHT;
 uint8_t frameBuffer[(324) * 244];
-uint16_t imageBuffer[(324) * 244]; DMAMEM
 uint8_t sendImageBuf[(324) * 244 * 2];
 uint8_t frameBuffer2[(324) * 244] DMAMEM;
 
@@ -232,13 +231,8 @@ uint16_t *last_dma_frame_buffer = nullptr;
 bool hm01b0_dma_callback(void *pfb) {
   //Serial.printf("Callback: %x\n", (uint32_t)pfb);
   if (tft.asyncUpdateActive()) return false; // don't use if we are already busy
-  uint8_t *pframeBuffer = (uint8_t*)pfb;
-  for (int i = 0; i < FRAME_HEIGHT * FRAME_WIDTH; i++) {
-    uint8_t b = *pframeBuffer++;
-    frameBuffer[i] = b;
-  }
   tft.setOrigin(-2, -2);
-  tft.writeRect8BPP(0, 0, FRAME_WIDTH, FRAME_HEIGHT, frameBuffer, mono_palette);
+  tft.writeRect8BPP(0, 0, FRAME_WIDTH, FRAME_HEIGHT, (uint8_t*)pfb, mono_palette);
   tft.setOrigin(0, 0);
   tft.updateScreenAsync();
 

--- a/TMM-HM01B0/src/HM01B0.cpp
+++ b/TMM-HM01B0/src/HM01B0.cpp
@@ -1317,14 +1317,14 @@ bool HM01B0::startReadFrameDMA(bool(*callback)(void *frame_buffer), uint8_t *fb1
 
   // configure DMA channels
   _dmachannel.begin();
-  _dmasettings[0].source(GPIO2_DR); // setup source.
+  _dmasettings[0].source(GPIO2_PSR); // setup source.
   _dmasettings[0].destinationBuffer(_dmaBuffer1, DMABUFFER_SIZE * 4);  // 32 bits per logical byte
   _dmasettings[0].replaceSettingsOnCompletion(_dmasettings[1]);
   _dmasettings[0].interruptAtCompletion();  // we will need an interrupt to process this.
   _dmasettings[0].TCD->CSR &= ~(DMA_TCD_CSR_DREQ); // Don't disable on this one
   //DebugDigitalToggle(OV7670_DEBUG_PIN_1);
 
-  _dmasettings[1].source(GPIO2_DR); // setup source.
+  _dmasettings[1].source(GPIO2_PSR); // setup source.
   _dmasettings[1].destinationBuffer(_dmaBuffer2, DMABUFFER_SIZE * 4);  // 32 bits per logical byte
   _dmasettings[1].replaceSettingsOnCompletion(_dmasettings[0]);
   _dmasettings[1].interruptAtCompletion();  // we will need an interrupt to process this.

--- a/TMM-HM01B0/src/HM01B0.cpp
+++ b/TMM-HM01B0/src/HM01B0.cpp
@@ -47,7 +47,7 @@ SOFTWARE.
 
 #define HIMAX_LINE_LEN_PCK_QQVGA    0x178
 #define HIMAX_FRAME_LENGTH_QQVGA    0x084
-//#define DEBUG_CAMERA
+#define DEBUG_CAMERA
 
 const uint16_t default_regs[][2] = {
     {BLC_TGT,              0x08},          //  BLC target :8  at 8 bit mode
@@ -1557,29 +1557,32 @@ void HM01B0::processDMAInterrupt() {
       _dma_state = DMA_STATE_STOPPED;
     } else {
       // We need to start up our ISR for the next frame. 
+#if 1
+  // bypass interrupt and just restart DMA... 
+  _bytes_left_dma = (w + _frame_ignore_cols) * h; // for now assuming color 565 image...
+  _dma_index = 0;
+  _frame_col_index = 0;  // which column we are in a row
+  _frame_row_index = 0;  // which row
+  _save_lsb = 0xffff;
+  // make sure our DMA is setup properly again. 
+  _dmasettings[0].transferCount(DMABUFFER_SIZE);
+  _dmasettings[0].TCD->CSR &= ~(DMA_TCD_CSR_DREQ); // Don't disable on this one
+  _dmasettings[1].transferCount(DMABUFFER_SIZE);
+  _dmasettings[1].TCD->CSR &= ~(DMA_TCD_CSR_DREQ); // Don't disable on this one
+  _dmachannel = _dmasettings[0];  // setup the first on...
+  _dmachannel.enable();
+
+#else
       attachInterrupt(VSYNC_PIN, &frameStartInterrupt, RISING);
+#endif
     }
   } else {
 
-#if 1
     if (_bytes_left_dma == (2 * DMABUFFER_SIZE)) {
       if (_dma_index & 1) _dmasettings[0].disableOnCompletion();
       else _dmasettings[1].disableOnCompletion();
     }
 
-#else
-    if (_bytes_left_dma <= (2 * DMABUFFER_SIZE)) {
-      if (_dma_index & 1) {
-        _dmasettings[0].disableOnCompletion();
-        if (_bytes_left_dma < DMABUFFER_SIZE)  _dmasettings[0].transferCount(_bytes_left_dma);
-        else   _dmasettings[0].transferCount(_bytes_left_dma - DMABUFFER_SIZE);
-      } else {
-        _dmasettings[1].disableOnCompletion();
-        if (_bytes_left_dma < DMABUFFER_SIZE)  _dmasettings[1].transferCount(_bytes_left_dma);
-        else   _dmasettings[0].transferCount(_bytes_left_dma - DMABUFFER_SIZE);
-      }
-    }
-#endif      
   }
   //DebugDigitalWrite(OV7670_DEBUG_PIN_3, LOW);
 }


### PR DESCRIPTION
@mjs513  @PaulStoffregen 

DMA is working better - right now

Was using wrong GPIO2 register.  Had DR (data register - mostly for output)
Should be using PSR (Pad Status Register).  

That helped.  I think the DR was offsetting the data by several reads... so was off...

Also changed to instead of starting up ISR to wait for VSYNC, which then restarted the DMA, I instead just restarted the DMA, figuring should not get any until the next vsync anyway... But may give some timing issues... That is maybe I restarted it after a VSYNC came in, still playing, but in case you wish to see it working better. 