### PR TITLE
Enable FrameBuffer on F/V free up memory

### DIFF
--- a/TMM-HM01B0/examples/Zelda-HM01B0/Zelda-HM01B0.ino
+++ b/TMM-HM01B0/examples/Zelda-HM01B0/Zelda-HM01B0.ino
@@ -299,6 +299,10 @@ void setup() {
   FRAME_WIDTH  = hm01b0.width();
   Serial.printf("ImageSize (w,h): %d, %d\n", FRAME_WIDTH, FRAME_HEIGHT);
 
+  // Lets setup camera interrupt priorities:
+  //hm01b0.setVSyncISRPriority(102); // higher priority than default
+  hm01b0.setDMACompleteISRPriority(192); // lower than default
+
   showCommandList();
 
 
@@ -388,7 +392,7 @@ void loop() {
   // Play the note on 'chan'
   if(opcode == CMD_PLAYNOTE) {
     unsigned char note = *sp++;
-    unsigned char velocity = *sp++;
+    unsigned char velocity __attribute__((unused)) = *sp++;
     wavetable[chan].playNote((byte)note);
     //OnNoteOn(chan, (byte)note, (byte)velocity);
     camLoop();

--- a/TMM-HM01B0/src/HM01B0.h
+++ b/TMM-HM01B0/src/HM01B0.h
@@ -175,6 +175,7 @@ class HM01B0
 	void setVSyncISRPriority(uint8_t priority) {NVIC_SET_PRIORITY(IRQ_GPIO6789, priority); }
 	void setDMACompleteISRPriority(uint8_t priority) {NVIC_SET_PRIORITY(dma_flexio.channel & 0xf, priority); }
 
+
 	//-------------------------------------------------------
 	uint16_t _width, _height;  //width, height
 	int16_t width(void) { return _width; }
@@ -246,6 +247,7 @@ class HM01B0
 	uint8_t *_frame_buffer_pointer;
 	uint8_t *_frame_row_buffer_pointer; // start of the row
 	uint8_t _dma_index;
+	bool 	_dma_active;
 	enum {DMASTATE_INITIAL=0, DMASTATE_RUNNING, DMASTATE_STOP_REQUESTED, DMA_STATE_STOPPED};
 	volatile uint8_t _dma_state;
 	static void dmaInterrupt(); 


### PR DESCRIPTION
The previous code never enabled Frame buffer, and the
current code did not have enough memory left to actually
create the frame buffer.

So for now I updated the code to not statically allocate that large array for
saving to SD Card when that option is turned off, so now the set Frame buffer works...

The code is setup currently with two #ifdef options
Either to draw on Camera frame complete or on
TFT frame complete.

There is some tearing or like issue when moving.  That's next...

@mjs513  and @Defragster  Warning I rebased this branch to start off from current main and then
had to fix a few conflicts.  So you should check to make
sure I did not screw it up!